### PR TITLE
Unread message counts in sidebar (for newly arriving posts)

### DIFF
--- a/js/app/models/PostNotifications.js
+++ b/js/app/models/PostNotifications.js
@@ -43,10 +43,17 @@ define(function(require) {
     },
 
     listen: function(options) {
+      if (!this._listening) {
+        this._listening = true;
+        this._doListen(options);
+      }
+    },
+
+    _doListen: function(options) {
       options = options || {};
       var self = this;
       options.complete = function() {
-        self.listen(options);
+        self._doListen(options);
       };
       this.fetch(options);
     }

--- a/templates/sidebar/channels.html
+++ b/templates/sidebar/channels.html
@@ -5,7 +5,7 @@
     <div class="avatar">
       <img data-type="<%- metadata.channelType() %>"
            src="<%= metadata.avatarUrl(50) %>" />
-      <!-- <span class="channelpost counter">2</span> -->
+      <span class="channelpost counter" style="display: none;">0</span>
     </div>
     <div class="info">
       <span class="owner"><%- metadata.title() %></span>


### PR DESCRIPTION
For now, this is limited to counting items posted while the client is running. Expanding this to items posted while not being online probably needs some HTTP-API-side bits (to be investigated), but this is at least a good start.
