### PR TITLE
localisation 

### DIFF
--- a/js/app/main.js
+++ b/js/app/main.js
@@ -66,7 +66,7 @@ define(function(require) {
     // everyone else
     lang = navigator.language;
   }
-  l10n.setAdapter(l10nBrowser, {baseURL: 'locales/'});
+  l10n.setAdapter(l10nBrowser, {baseURL: '/locales/'});
   l10n.setMarkFallbacks();
   l10n.loadResource('data.properties', lang, 
       initialize, // do this once the locale data has loaded


### PR DESCRIPTION
This should help with fixing https://github.com/buddycloud/webclient/issues/92

I've changed the path where locale files are loaded from to include a leading slash. 

The underscores are markers which show that a string can't be found in the locale file.

Sysadmins may also need to change their rewrite rules to make an exception for /locales/.
