### PR TITLE
Escaped strings inside tags

### DIFF
--- a/templates/content/editHeader.html
+++ b/templates/content/editHeader.html
@@ -1,6 +1,6 @@
 <img class="avatar" src="<%= metadata.avatarUrl(75) %>">
 <div class="flex titleText">
   <h2 class="owner"><%= metadata.channel %></h2>
-  <div class="about"><%= metadata.description() %></div>
+  <div class="about"><%- metadata.description() %></div>
 </div>
 <a href="http://www.buddycloud.com" id="poweredby" data-l10n="poweredBy">powered by buddycloud</a>

--- a/templates/content/header.html
+++ b/templates/content/header.html
@@ -1,7 +1,7 @@
 <img class="avatar" src="<%= metadata.avatarUrl(75) %>">
 <div class="flex titleText">
-  <h2 class="owner" title="<%= metadata.title() %>"><%= metadata.title() %></h2>
-  <div class="about" title="<%= metadata.description() %>"><%= metadata.description() %></div>
+  <h2 class="owner" title="<%= metadata.title() %>"><%- metadata.title() %></h2>
+  <div class="about" title="<%= metadata.description() %>"><%- metadata.description() %></div>
 </div>
 <nav class="inChannel">
   <span class="edit button" data-l10n="editButton">Edit</span>

--- a/templates/content/post.html
+++ b/templates/content/post.html
@@ -7,7 +7,7 @@
   <div class="postmeta">
     <time class="timeago" data-strftime="%d.%m.%Y %H:%M" data-strftitle="%A %d %B %Y %H:%M" datetime="<%= post.updated %>"></time>
   </div>
-  <p><%= linkify(post.content) %></p>
+  <p><%- linkify(post.content) %></p>
 </section>
 <section class="comments">
   <% _.each(post.comments, function(comment) { %>
@@ -20,7 +20,7 @@
        <div class="postmeta">
          <time class="timeago" data-strftime="%d.%m.%Y %H:%M" data-strftitle="%A %d %B %Y %H:%M" datetime="<%= comment.updated %>"></time>
        </div>
-       <p><%= linkify(comment.content) %></p>
+       <p><%- linkify(comment.content) %></p>
      </section>
   <% }) %>
   <section class="answer">

--- a/templates/sidebar/personalChannel.html
+++ b/templates/sidebar/personalChannel.html
@@ -5,8 +5,8 @@
     <!-- <span class="message counter">2</span> -->
   </div>
   <div class="info">
-    <span class="owner"><%= metadata.title() %></span>
-    <span class="status"><%= metadata.description() %></span>
+    <span class="owner"><%- metadata.title() %></span>
+    <span class="status"><%- metadata.description() %></span>
   </div>
 </div>
 <div class="settings noSelect">


### PR DESCRIPTION
This is a quick fix to a bug reported by nylz@buddycloud.org on report_bugs@topics.buddycloud.org. Embedded html in posts wasn't escaped. I've also had a look through the rest of the templates, and escaped a few other strings that seemed relevant. 

I haven't escaped strings in html attributes, because I wasn't sure of the best way to do this.
