### PR TITLE
escaped tag attributes

### DIFF
--- a/templates/content/channelList.html
+++ b/templates/content/channelList.html
@@ -2,9 +2,9 @@
 <div class="list">
   <% _.each(channels, function(channel, index) { %>
     <% if (index < 8) { %>
-    <img title="<%= channel %>" src="<%= avatarUrl(channel, 50) %>">
+    <img title="<%- channel %>" src="<%- avatarUrl(channel, 50) %>">
     <% } else { %>
-    <img title="<%= channel %>" src="<%= avatarUrl(channel, 50) %>" style="display: none">
+    <img title="<%- channel %>" src="<%- avatarUrl(channel, 50) %>" style="display: none">
     <% } %>
   <% }); %>
   <% if (channels.length > 8) { %>

--- a/templates/content/discover.html
+++ b/templates/content/discover.html
@@ -6,8 +6,8 @@
       <% if (mostActive) { %>
       <div class="list">
         <% _.each(mostActive, function(channel) { %>
-        <div class="channel justify" id="<%= channel.jid() %>">
-          <img class="avatar" data-type="<%= channel.channelType() %>" src="<%= channel.jidAvatarUrl(50) %>"></img>
+        <div class="channel justify" id="<%- channel.jid() %>">
+          <img class="avatar" data-type="<%- channel.channelType() %>" src="<%- channel.jidAvatarUrl(50) %>"></img>
           <div class="info flex">
             <span class="owner"><%- channel.title() %></span>
             <span class="about"><%- channel.description() %></span>
@@ -23,8 +23,8 @@
       <% if (recommended) { %>
       <div class="list">
         <% _.each(recommended, function(channel) { %>
-        <div class="channel justify" id="<%= channel.jid() %>">
-          <img class="avatar" data-type="<%= channel.channelType() %>" src="<%= channel.jidAvatarUrl(50) %>"></img>
+        <div class="channel justify" id="<%- channel.jid() %>">
+          <img class="avatar" data-type="<%- channel.channelType() %>" src="<%- channel.jidAvatarUrl(50) %>"></img>
           <div class="info flex">
             <span class="owner"><%- channel.title() %></span>
             <span class="about"><%- channel.description() %></span>
@@ -43,8 +43,8 @@
       <% if (mostActive) { %>
       <div class="list">
         <% _.each(mostActive, function(channel) { %>
-        <div class="channel justify" id="<%= channel.jid() %>">
-          <img class="avatar" data-type="<%= channel.channelType() %>" src="<%= channel.jidAvatarUrl(50) %>"></img>
+        <div class="channel justify" id="<%- channel.jid() %>">
+          <img class="avatar" data-type="<%- channel.channelType() %>" src="<%- channel.jidAvatarUrl(50) %>"></img>
           <div class="info flex">
             <span class="owner"><%- channel.title() %></span>
             <span class="about"><%- channel.description() %></span>
@@ -60,8 +60,8 @@
       <% if (recommended) { %>
       <div class="list">
         <% _.each(recommended, function(channel) { %>
-        <div class="channel justify" id="<%= channel.jid() %>">
-          <img class="avatar" data-type="<%= channel.channelType() %>" src="<%= channel.jidAvatarUrl(50) %>"></img>
+        <div class="channel justify" id="<%- channel.jid() %>">
+          <img class="avatar" data-type="<%- channel.channelType() %>" src="<%- channel.jidAvatarUrl(50) %>"></img>
           <div class="info flex">
             <span class="owner"><%- channel.title() %></span>
             <span class="about"><%- channel.description() %></span>

--- a/templates/content/editChannel.html
+++ b/templates/content/editChannel.html
@@ -9,7 +9,7 @@
   </div>
   <div class="title">
     <label for="channel_title" data-l10n="channelTitle">Channel title</label>
-    <input type="text" id="channel_title" value="<%= metadata.title() || '' %>"/>
+    <input type="text" id="channel_title" value="<%- metadata.title() || '' %>"/>
   </div>
   <div class="description area">
     <label for="channel_description" data-l10n="channelDescription">Channel description</label>
@@ -19,7 +19,7 @@
     Not handled yet
   <div class="status">
     <label for="channel_mood">Status</label>
-    <input type="text" id="channel_status" placeholder="How are you doing?" value="<%= metadata.description() || '' %>"/>
+    <input type="text" id="channel_status" placeholder="How are you doing?" value="<%- metadata.description() || '' %>"/>
   </div> -->
   <!--
     Location isn't currently handled 

--- a/templates/content/embed.html
+++ b/templates/content/embed.html
@@ -1,15 +1,15 @@
 <div class="embed">
 <% if (title) { %>
-  <a class="title" href="<%= url %>"><%= title %></a>
+  <a class="title" href="<%- url %>"><%- title %></a>
 <% }
    if (html) { print(html); }
    else if (img) { %>
-  <a href="<%= url %>">
-    <img src="<%= img %>" width="<%= Math.min(maxWidth, width) %>"
-    <% if (description) { %>alt="<%= description %>"<% } %>/>
+  <a href="<%- url %>">
+    <img src="<%- img %>" width="<%= Math.min(maxWidth, width) %>"
+    <% if (description) { %>alt="<%- description %>"<% } %>/>
   </a>
 <% }
    if (description && description.length > 0) { %>
-  <div class="description"><%= description %></div>
+  <div class="description"><%- description %></div>
 <% } %>
 </div>

--- a/templates/content/header.html
+++ b/templates/content/header.html
@@ -1,7 +1,7 @@
-<img class="avatar" src="<%= metadata.avatarUrl(75) %>">
+<img class="avatar" src="<%- metadata.avatarUrl(75) %>">
 <div class="flex titleText">
-  <h2 class="owner" title="<%= metadata.title() %>"><%- metadata.title() %></h2>
-  <div class="about" title="<%= metadata.description() %>"><%- metadata.description() %></div>
+  <h2 class="owner" title="<%- metadata.title() %>"><%- metadata.title() %></h2>
+  <div class="about" title="<%- metadata.description() %>"><%- metadata.description() %></div>
 </div>
 <nav class="inChannel">
   <span class="edit button" data-l10n="editButton">Edit</span>

--- a/templates/content/post.html
+++ b/templates/content/post.html
@@ -1,24 +1,24 @@
 <section class="opener <%= roleTag(post.author) %>">
-  <img class="avatar" src="<%= post.authorAvatarUrl(50) %>" />
+  <img class="avatar" src="<%- post.authorAvatarUrl(50) %>" />
   <div class="usermeta">
-    <div class="name"><%= post.author.split('@', 2)[0] %></div>
-    <div class="jid"><%= post.author %></div>
+    <div class="name"><%- post.author.split('@', 2)[0] %></div>
+    <div class="jid"><%- post.author %></div>
   </div>
   <div class="postmeta">
-    <time class="timeago" data-strftime="%d.%m.%Y %H:%M" data-strftitle="%A %d %B %Y %H:%M" datetime="<%= post.updated %>"></time>
+    <time class="timeago" data-strftime="%d.%m.%Y %H:%M" data-strftitle="%A %d %B %Y %H:%M" datetime="<%- post.updated %>"></time>
   </div>
   <p><%= linkify(post.content) %></p>
 </section>
 <section class="comments">
   <% _.each(post.comments, function(comment) { %>
      <section class="comment <%= roleTag(comment.author) %>">
-       <img class="avatar" src="<%= comment.authorAvatarUrl(34) %>" />
+       <img class="avatar" src="<%- comment.authorAvatarUrl(34) %>" />
        <div class="usermeta">
-         <div class="name"><%= comment.author.split('@', 2)[0] %></div>
-         <div class="jid"><%= comment.author %></div>
+         <div class="name"><%- comment.author.split('@', 2)[0] %></div>
+         <div class="jid"><%- comment.author %></div>
        </div>
        <div class="postmeta">
-         <time class="timeago" data-strftime="%d.%m.%Y %H:%M" data-strftitle="%A %d %B %Y %H:%M" datetime="<%= comment.updated %>"></time>
+         <time class="timeago" data-strftime="%d.%m.%Y %H:%M" data-strftitle="%A %d %B %Y %H:%M" datetime="<%- comment.updated %>"></time>
        </div>
        <p><%= linkify(comment.content) %></p>
      </section>
@@ -27,7 +27,7 @@
     <div class="holder">
       <div class="expandingArea">
         <pre><span></span><br></pre>
-      <textarea placeholder="<%= l('commentHint', {}, 'comment') %>"></textarea>
+      <textarea placeholder="<%- l('commentHint', {}, 'comment') %>"></textarea>
       </div>
       <div class="controls clearfix">
         <div class="hint" data-l10n="postHint">ctrl + enter to post</div>

--- a/templates/content/preferences.html
+++ b/templates/content/preferences.html
@@ -2,7 +2,7 @@
   <h2 class="pageName" data-l10n="preferences">Preferences</h2>
   <div class="email">
     <label for="email_address" data-l10n="email">Email</label>
-    <input type="text" id="email_address" value="<%= preferences.email() %>" />
+    <input type="text" id="email_address" value="<%- preferences.email() %>" />
   </div>
   <div class="notify">
     <label data-l10n="notifications">Notifications</label>

--- a/templates/content/searchResults.html
+++ b/templates/content/searchResults.html
@@ -5,8 +5,8 @@
       <% if (channels) { %>
       <div class="list">
         <% _.each(channels, function(channel) { %>
-        <div class="channel justify" id="<%= channel.jid() %>">
-          <img class="avatar" data-type="<%= channel.channelType() %>" src="<%= channel.jidAvatarUrl(50) %>"></img>
+        <div class="channel justify" id="<%- channel.jid() %>">
+          <img class="avatar" data-type="<%- channel.channelType() %>" src="<%- channel.jidAvatarUrl(50) %>"></img>
           <div class="info flex">
             <span class="owner"><%- channel.title() %></span>
             <span class="about"><%- channel.description() %></span>
@@ -24,9 +24,9 @@
         <% _.each(posts, function(post) { %>
         <article class="post">
           <section class="opener">
-            <img class="avatar" data-type="personal" src="<%= post.authorAvatarUrl(50) %>"></img>
+            <img class="avatar" data-type="personal" src="<%- post.authorAvatarUrl(50) %>"></img>
               <div class="postmeta">
-                <time class="ago" data-strftime="%d.%m.%Y %H:%M" data-strftitle="%A %d %B %Y %H:%M" datetime="<%= post.published() %>" title="<%= post.published() %>">3 days</time>
+                <time class="ago" data-strftime="%d.%m.%Y %H:%M" data-strftitle="%A %d %B %Y %H:%M" datetime="<%- post.published() %>" title="<%- post.published() %>">3 days</time>
               </div>
             <p><%- post.content() %></p>
           </section>

--- a/templates/content/stream.html
+++ b/templates/content/stream.html
@@ -1,5 +1,5 @@
 <section class="newTopic">
-  <img class="avatar" src="<%= user.avatarUrl(50) %>">
+  <img class="avatar" src="<%- user.avatarUrl(50) %>">
   <div class="holder">
     <div class="expandingArea">
         <pre><span></span><br></pre>

--- a/templates/overlay/discover.html
+++ b/templates/overlay/discover.html
@@ -5,8 +5,8 @@
       <% if (mostActive) { %>
       <div class="list">
         <% _.each(mostActive, function(channel) { %>
-        <div class="channel justify" id="<%= channel.jid() %>">
-          <img class="avatar" data-type="<%= channel.channelType() %>" src="<%= channel.jidAvatarUrl(50) %>"></img>
+        <div class="channel justify" id="<%- channel.jid() %>">
+          <img class="avatar" data-type="<%- channel.channelType() %>" src="<%- channel.jidAvatarUrl(50) %>"></img>
           <div class="info flex">
             <span class="owner"><%- channel.title() %></span>
             <span class="about"><%- channel.description() %></span>
@@ -21,8 +21,8 @@
       <% if (popular) { %>
       <div class="list">
         <% _.each(popular, function(channel) { %>
-        <div class="channel justify" id="<%= channel.jid() %>">
-          <img class="avatar" data-type="<%= channel.channelType() %>" src="<%= channel.jidAvatarUrl(50) %>"></img>
+        <div class="channel justify" id="<%- channel.jid() %>">
+          <img class="avatar" data-type="<%- channel.channelType() %>" src="<%- channel.jidAvatarUrl(50) %>"></img>
           <div class="info flex">
             <span class="owner"><%- channel.title() %></span>
             <span class="about"><%- channel.description() %></span>
@@ -41,7 +41,7 @@
       <div class="list">
         <% _.each(mostActive, function(channel) { %>
         <div class="channel justify">
-          <img class="avatar" data-type="<%= channel.channelType() %>" src="<%= channel.jidAvatarUrl(50) %>"></img>
+          <img class="avatar" data-type="<%- channel.channelType() %>" src="<%- channel.jidAvatarUrl(50) %>"></img>
           <div class="info flex">
             <span class="owner"><%- channel.title() %></span>
             <span class="about"><%- channel.description() %></span>
@@ -57,7 +57,7 @@
       <div class="list">
         <% _.each(popular, function(channel) { %>
         <div class="channel justify">
-          <img class="avatar" data-type="<%= channel.channelType() %>" src="<%= channel.jidAvatarUrl(50) %>"></img>
+          <img class="avatar" data-type="<%- channel.channelType() %>" src="<%- channel.jidAvatarUrl(50) %>"></img>
           <div class="info flex">
             <span class="owner"><%- channel.title() %></span>
             <span class="about"><%- channel.description() %></span>

--- a/templates/sidebar/channel.html
+++ b/templates/sidebar/channel.html
@@ -2,7 +2,7 @@
      data-href="<%- metadata.channel %>">
   <div class="avatar">
     <img data-type="<%- metadata.channelType() %>"
-         src="<%= metadata.avatarUrl(75) %>" />
+         src="<%- metadata.avatarUrl(75) %>" />
     <span class="channelpost counter" style="display: none;">0</span>
   </div>
   <div class="info">

--- a/templates/sidebar/channels.html
+++ b/templates/sidebar/channels.html
@@ -4,7 +4,7 @@
        data-href="<%- metadata.channel %>">
     <div class="avatar">
       <img data-type="<%- metadata.channelType() %>"
-           src="<%= metadata.avatarUrl(50) %>" />
+           src="<%- metadata.avatarUrl(50) %>" />
       <span class="channelpost counter" style="display: none;">0</span>
     </div>
     <div class="info">

--- a/templates/sidebar/personalChannel.html
+++ b/templates/sidebar/personalChannel.html
@@ -1,6 +1,6 @@
 <div class="metadata">
   <div class="avatar">
-    <img src="<%= metadata.avatarUrl(50) %>" />
+    <img src="<%- metadata.avatarUrl(50) %>" />
     <!-- <span class="channelpost counter">2</span> -->
     <!-- <span class="message counter">2</span> -->
   </div>


### PR DESCRIPTION
This fixes some possible security holes, where user-derived content is included in html tag attributes without being escaped.

I've been pretty cautious, and escaped nearly every attribute in the templates. There might be some that could have been left unescaped, but it seemed safer and easier to do them all.

I've tested the modified code on my localhost webclient, and it doesn't break anything obvious.

This resolves issue: https://github.com/buddycloud/webclient/issues/124

andy
