### PR TITLE
Add grunt.js project file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,25 @@
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+
+    connect: {
+      app: {
+        options: {
+          port: 8000,
+          base: ''
+        }
+      }
+    },
+
+    watch: {}
+  });
+
+  // Plug-ins
+  grunt.loadNpmTasks('grunt-contrib-connect');
+  grunt.loadNpmTasks('grunt-contrib-watch');
+
+  // Tasks
+  grunt.registerTask('default', ['server']);
+  grunt.registerTask('server', ['connect', 'watch']);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "buddycloud-webclient",
+  "version": "0.0.0",
+  "author": "buddycloud",
+  "description": "Web interface for the buddycloud network",
+  "license": "Apache 2.0",
+  "devDependencies": {
+    "grunt": "~0.4.0",
+    "grunt-contrib-connect": "~0.1.0",
+    "grunt-contrib-watch": "~0.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/buddycloud/buddycloud-webclient.git"
+  },
+  "engine": {
+    "node": ">=0.8"
+  }
+}


### PR DESCRIPTION
Since last year, [grunt.js](https://github.com/gruntjs/grunt) is very quickly becoming the absolute standard "build system" for client-side JavaScript apps. This will certainly be a fine tool to fulfill our minification, deployment etc. needs.

The pull request includes a very simple Gruntfile which allows you to spin up a development server at port 8000 with `grunt server`.

Note that this uses grunt.js 0.4.x (`npm install -g grunt-cli`) rather than the "stable" (but nearly obsolete) 0.3.x version. Also, make sure to run `npm install` in the webclient root directory, otherwise it won't work.
