### PR TITLE
Add comment about using Embedly

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,6 +2,10 @@ define({
   baseUrl: 'https://api.EXAMPLE.COM',
   homeDomain: 'EXAMPLE.COM',
   defaultChannel: 'lounge@topics.buddycloud.org',
+  // To enable Embedly, you must sign up on the http://embed.ly website.
+  // If you are not using Embedly, you may see "some content is unencrypted"
+  // messages while browsing, which can be solved by changing embedlySecure
+  // to "true".
   embedlyKey: '',
   embedlySecure: false,
   release: true


### PR DESCRIPTION
I was getting "some content is unencrypted" messages and didn't think it
had anything to do with embedly (as I hadn't set it up yet), but the FF
developer console told a different story. Setting "embedlySecure: true"
solved the problem. Using "true" as default may break things (as it's still in beta upstream), so just add a comment instead.
