### PR TITLE
Allow user to specify a port number for dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ results
 
 npm-debug.log
 node_modules
+
+.project
+.settings
+config.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,6 @@
+var requirejs = require('requirejs')
+var config    = requirejs('./config.js')
+
 module.exports = function(grunt) {
 
   grunt.initConfig({
@@ -47,9 +50,9 @@ module.exports = function(grunt) {
         res.send(file);
       });
     });
-    app.listen(3000);
-
-    console.log('Listening on port 3000...');
+    var port = config.port || 3000;
+    app.listen(port);
+    console.log('Listening on port ' + port + '...');
   });
 
 }

--- a/config.js.example
+++ b/config.js.example
@@ -16,4 +16,7 @@ define({
   // If you see "some content is unencrypted" messages while browsing, change 
   // embedlySecure to "true".
   embedlySecure: true,
+
+  // Specify a port number to run the server on (defaults to 3000)
+  // port: 3000,
 });

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   },
   "engine": {
     "node": ">=0.8"
+  },
+  "dependencies": {
+    "requirejs": "~2.1.5"
   }
 }


### PR DESCRIPTION
When running both the http api and the webclient development server on the same machine then by default the same port number is used.
