### PR TITLE
Trigger 'fetch' regardless of callback success

### DIFF
--- a/js/app/models/Channel.js
+++ b/js/app/models/Channel.js
@@ -34,7 +34,6 @@ define(function(require) {
       });
       this.followers.fetch(options);
       this.similarChannels.fetch(options);
-      this.trigger('fetch')
     },
 
     _triggerFetchCallback: function() {

--- a/js/app/views/content/ChannelDetails.js
+++ b/js/app/views/content/ChannelDetails.js
@@ -33,7 +33,7 @@ define(function(require) {
       this.model = new Channel(this.options.channel);
       this.model.bind('fetch', this.render, this);
       this.model.fetch({credentials: this.options.user.credentials});
-
+      this.render();
       if (this.options.user.subscribedChannels) {
         this.options.user.subscribedChannels.bind('subscriptionSync', this._updateFollowersList, this);
       }


### PR DESCRIPTION
If the 'channel-directory' server isn't running then the similar channels endpoint returns a 500 response (should it really be 410?).  This prevents the sidebar from being rendered as the 'fetch' event is not triggered.

This fix fires the 'fetch' event regardless and renders the sidebar for all of the people not running this additional component.
