### PR TITLE
Render channel list even if /sync endpoint errors

### DIFF
--- a/js/app/views/sidebar/Channels.js
+++ b/js/app/views/sidebar/Channels.js
@@ -58,7 +58,8 @@ define(function(require) {
       var options = {
         data: {'since': this.model.lastSession, 'max': 51, counters: 'true'},
         credentials: this.model.credentials,
-        success: this._updateCounters()
+        success: this._updateCounters(),
+        fail: this.render()
       };
 
       this.sync = new Sync();


### PR DESCRIPTION
Even when /sync endpoint 500's we should still list subscribed channels
