### PR TITLE
Edit Channel's UI bug fix: hint texts overlapping.

### DIFF
--- a/js/app/views/content/EditChannelStream.js
+++ b/js/app/views/content/EditChannelStream.js
@@ -62,6 +62,7 @@ define(function(require) {
       }));
       this._fillCheckbox();
       this._selectDefaultRole();
+      this._toggleHint();
       document.redraw();
     },
 


### PR DESCRIPTION
Fixed texts overlapping by calling method to toggle correct hint on render.
